### PR TITLE
update desimodel location

### DIFF
--- a/input/template_fiberassign.txt
+++ b/input/template_fiberassign.txt
@@ -2,8 +2,8 @@ Targfile {inputdir}/mtl.fits
 SStarsfile {targetdir}/stdstars.fits
 SkyFfile  {targetdir}/sky.fits
 Secretfile {targetdir}/truth.fits
-tileFile /project/projectdirs/desi/software/edison/desimodel/master/data/footprint/desi-tiles.fits
-fibFile /project/projectdirs/desi/software/edison/desimodel/0.3.1/data/focalplane/fiberpos.txt
+tileFile /global/common/edison/contrib/desi/code/desimodel/0.5.1/data/footprint/desi-tiles.fits
+fibFile /global/common/edison/contrib/desi/code/desimodel/0.5.1/data/focalplane/fiberpos.txt
 outDir {inputdir}/fiberassign/
 surveyFile {inputdir}/survey_list.txt
 


### PR DESCRIPTION
This PR updates the location of desimodel in `template_fiberassign.txt` .  It was previously pointing to an out-of-date master checkout of desimodel with an old desi-tiles.fits file; this now points to an installation of tag 0.5.1.  I'm submitting this via a PR so that @forero can merge it when he is ready and not have it changed out from under him.  Any copies of `template_fiberassign.txt` should be updated prior to reference runs for the Ohio meeting this week.

